### PR TITLE
Fix traceback

### DIFF
--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -231,7 +231,7 @@ class ParseProcessLog(list):
 
         # Now walk through the remaining columns, which will contain API
         # arguments.
-        for index in range(8, len(row)):
+        for index in range(9, len(row)):
             argument = {}
 
             # Split the argument name with its value based on the separator.


### PR DESCRIPTION
Didn't account for the new column format when starting to parse the rest of the arguments for the row. Resulted in trying to iterate a list which was likely an int.
