### PR TITLE
Update Suricata components

### DIFF
--- a/web/templates/analysis/network/_suricata_alerts.html
+++ b/web/templates/analysis/network/_suricata_alerts.html
@@ -3,14 +3,29 @@
     {% if analysis.suricata.alerts %}
         <table class="table table-striped table-bordered">
             <tr>
-                <th>Alert</th>
+                <th>Timestamp</th>
+                <th>Source IP</th>
+                <th>Source Port</th>
+                <th>Destination IP</th>
+                <th>Destination Port</th>
+                <th>Protocol</th>
+                <th>Signature</th>
+                <th>Category</th>
             </tr>
             {% for alert in analysis.suricata.alerts %}
             <tr>
-                <td>{{alert}}</td>
+                <td>{{alert.timestamp}}</td>
+                <td>{{alert.srcip}}</td>
+                <td>{{alert.srcport}}</td>
+                <td>{{alert.dstip}}</td>
+                <td>{{alert.dstport}}</td>
+                <td>{{alert.protocol}}</td>
+                <td>{{alert.signature}}</td>
+                <td>{{alert.category}}</td>
             </tr>
             {% endfor %}
         </table>
+
     {% else %}
         <p>No Suricata Alerts</p>
     {% endif %}

--- a/web/templates/analysis/network/_suricata_http.html
+++ b/web/templates/analysis/network/_suricata_http.html
@@ -1,16 +1,37 @@
 <section id="suri_http">
     <h4>Suricata HTTP</h4>
     {% if analysis.suricata.http %}
-        <table class="table table-striped table-bordered">
+        <table class="table table-striped table-bordered" style="table-layout: fixed; width: 100%">
             <tr>
-                <th>HTTP LOG</th>
+                <th width="8%">Timestamp</th>
+                <th width="9%">Source IP</th>
+                <th width="7%">Source Port</th>
+                <th width="9%">Destination IP</th>
+                <th width="9%">Destination Port</th>
+                <th width="4%">Method</th>
+                <th width="12%">Hostname</th>
+                <th width="15%">URI</th>
+                <th width="10%">Content Type</th>
+                <th width="13%">User Agent</th>
+                <th width="4%">Length</th>
             </tr>
-            {% for e in analysis.suricata.http %}
+            {% for http in analysis.suricata.http %}
             <tr>
-                <td>{{e}}</td>
+                <td>{{http.timestamp}}</td>
+                <td>{{http.srcip}}</td>
+                <td>{{http.srcport}}</td>
+                <td>{{http.dstip}}</td>
+                <td>{{http.dstport}}</td>
+                <td>{{http.method}}</td>
+                <td>{{http.hostname}}</td>
+                <td>{{http.uri}}</td>
+                <td>{{http.contenttype}}</td>
+                <td>{{http.ua}}</td>
+                <td>{{http.length}}</td>
             </tr>
             {% endfor %}
         </table>
+
     {% else %}
         <p>No Suricata HTTP</p>
     {% endif %}

--- a/web/templates/analysis/network/_suricata_tls.html
+++ b/web/templates/analysis/network/_suricata_tls.html
@@ -3,14 +3,31 @@
     {% if analysis.suricata.tls %}
         <table class="table table-striped table-bordered">
             <tr>
-                <th>TLS</th>
+                <th>Timestamp</th>
+                <th>Source IP</th>
+                <th>Source Port</th>
+                <th>Destination IP</th>
+                <th>Destination Port</th>
+                <th>Version</th>
+                <th>Issuer</th>
+                <th>Subject</th>
+                <th>Fingerprint</th>
             </tr>
-            {% for e in analysis.suricata.tls %}
+            {% for tls in analysis.suricata.tls %}
             <tr>
-                <td>{{e}}</td>
+                <td>{{tls.timestamp}}</td>
+                <td>{{tls.srcip}}</td>
+                <td>{{tls.srcport}}</td>
+                <td>{{tls.dstip}}</td>
+                <td>{{tls.dstport}}</td>
+                <td>{{tls.version}}</td>
+                <td>{{tls.issuer}}</td>
+                <td>{{tls.subject}}</td>
+                <td>{{tls.fingerprint}}</td>
             </tr>
             {% endfor %}
         </table>
+
     {% else %}
         <p>No Suricata TLS</p>
     {% endif %}


### PR DESCRIPTION
Formalize logs using the EVE logger and just read the single JSON file it produces, instead of log files for each section. Parse out fields and represent them in django appropriately instead of just read and outputting the log file line-by-line.
