### PR TITLE
Logger Error in suricata.py

### DIFF
--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -135,8 +135,8 @@ class Suricata(Processing):
             return suricata["alerts"]
 
         if os.path.exists(SURICATA_EVE_LOG_FULL_PATH):
-            with open(SURICATA_EVE_LOG_FULL_PATH, "r") as log:
-                data = log.read()
+            with open(SURICATA_EVE_LOG_FULL_PATH, "r") as eve_log:
+                data = eve_log.read()
 
             for line in data.splitlines():
                 parsed = json.loads(line)


### PR DESCRIPTION
the global log variable was being overwritten with the suricata event log file handle causing any log calls to cause an unhandled exception (trying to call .warning(), .error(), etc on a closed file handle rather than a logger object) 
