### PR TITLE
If root, skip check for cap_net_admin,cap_net_raw+eip on tcpdump

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -39,14 +39,14 @@ class Sniffer(Auxiliary):
             resultserver_port = str(self.machine.resultserver_port)
         else:
             resultserver_port = str(Config().resultserver.port)
-            
+
         if not os.path.exists(tcpdump):
             log.error("Tcpdump does not exist at path \"%s\", network "
                       "capture aborted", tcpdump)
             return
 
         mode = os.stat(tcpdump)[stat.ST_MODE]
-        if (mode & stat.S_ISUID) == 0:
+        if (mode & stat.S_ISUID) == 0 and os.geteuid() > 0:
             # now do a weak file capability check
             has_caps = False
             try:


### PR DESCRIPTION
Ran into this when testing, found it useful to skip this check rather than having to modify permissions on tcpdump.
