### PR TITLE
Add some yara rules to trigger on various malware configs

### DIFF
--- a/data/yara/memory/dridex.yar
+++ b/data/yara/memory/dridex.yar
@@ -1,0 +1,45 @@
+// Copyright (C) 2010-2014 Cuckoo Foundation.
+// This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+// See the file 'docs/LICENSE' for copying permission.
+
+// The contents of this file are Yara rules processed by procmemory.py processing
+// module. Add your signatures here.
+rule DridexCfgBotID
+{
+    meta:
+        author = "KillerInstinct"
+        description = "Configuration element for Dridex Bot ID"
+
+    strings:
+        $buf = /(\<cfg net)?=\"\d+\"\shash=.*bottickmin=\"\d+\"\sbottickmax=\"\d+\"\snodetickmin=\"\d+\"\snodetickmax=\"\d+\"\sport=\"\d+\"\sstatus=\"\d+\"\sbuild=\"\d+\"\>/s
+
+    condition:
+        $buf
+}
+
+rule DridexCfgNodeList
+{
+    meta:
+        author = "KillerInstinct"
+        description = "Configuration element for Dridex node list"
+
+    strings:
+        $buf = /\<node\>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*\<\/node\>/s
+
+    condition:
+        $buf
+}
+
+rule DridexCfgKeylog
+{
+    meta:
+        author = "KillerInstinct"
+        description = "Configuration element for Dridex keylogger"
+
+    strings:
+        $buf = /\<latest.*\keylog=.*\/\>/s
+
+    condition:
+        $buf
+}
+

--- a/data/yara/memory/dyre.yar
+++ b/data/yara/memory/dyre.yar
@@ -1,0 +1,31 @@
+// Copyright (C) 2010-2014 Cuckoo Foundation.
+// This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+// See the file 'docs/LICENSE' for copying permission.
+
+// The contents of this file are Yara rules processed by procmemory.py processing
+// module. Add your signatures here.
+rule DyreCfgServerList
+{
+    meta:
+        author = "KillerInstinct"
+        description = "Configuration element for Dyre server list"
+
+    strings:
+        $buf = /\<serverlist\>.*\<\/serverlist\>/s
+
+    condition:
+        $buf
+}
+
+rule DyreCfgInjectsList
+{
+    meta:
+        author = "KillerInstinct"
+        description = "Configuration element for Dyre web injects"
+
+    strings:
+        $buf = /\<litem\>.*\<\/litem\>/s
+
+    condition:
+        $buf
+}

--- a/data/yara/memory/index_memory.yar
+++ b/data/yara/memory/index_memory.yar
@@ -1,6 +1,0 @@
-// Copyright (C) 2010-2014 Cuckoo Foundation.
-// This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
-// See the file 'docs/LICENSE' for copying permission.
-
-// The contents of this file are Yara rules processed by procmemory.py processing
-// module. Add your signatures here.

--- a/lib/cuckoo/common/office/vbadeobf.py
+++ b/lib/cuckoo/common/office/vbadeobf.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation, KillerInstinct
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
 import string
 
 try:


### PR DESCRIPTION
Removed the placeholder index file. Note that these rules were based off of memory dumps from personal testing. So if you run a sample with a longer timeout, you may get different memory sections. With that said, these could probably see some improvement, or more rules added later. Also added a copyright to the VBA parsing file.
