### PR TITLE
Maintain tab state in analysis reports

### DIFF
--- a/web/templates/analysis/report.html
+++ b/web/templates/analysis/report.html
@@ -62,4 +62,18 @@
         {% include "analysis/admin/index.html" %}
     </div>
 </div>
+<script>
+$(function() {
+  //for bootstrap 3 use 'shown.bs.tab' instead of 'shown' in the next line
+  $('a[data-toggle="tab"]').on('click', function (e) {
+    localStorage.setItem('lastAnalysisTab', $(e.target).attr('href'));
+  });
+
+  var lastAnalysisTab = localStorage.getItem('lastAnalysisTab');
+
+  if (lastAnalysisTab) {
+      $('a[href="'+lastAnalysisTab+'"]').click();
+  }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
POSTing a comment now reloads you to the comment page. This code is basically reused from the analysis page.
