### PR TITLE
Analysis started statistic collection

### DIFF
--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -253,7 +253,6 @@ class AnalysisManager(Thread):
             log.error("Cannot acquire machine: {0}".format(e))
             return False
 
-        Database().set_statistics_time(self.task.id, ANALYSIS_STARTED)
         # Generate the analysis configuration file.
         options = self.build_options()
 
@@ -283,6 +282,8 @@ class AnalysisManager(Thread):
 
             # Start the analysis.
             guest.start_analysis(options)
+
+            Database().set_statistics_time(self.task.id, ANALYSIS_STARTED)
 
             guest.wait_for_completion()
             succeeded = True


### PR DESCRIPTION
Discovered whilst testing that the analysis started stat is collected well before the analysis has in fact started.  

It is particularly useful to be able to tell exactly when the analysis started to determine how much time is remaining before the analysis critical timeout is reached.
