### PR TITLE
Crash when deleting tasks during results processing

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -544,6 +544,10 @@ class Database(object):
         session = self.Session()
         try:
             row = session.query(Task).get(task_id)
+            
+            if not row:
+                return
+            
             row.status = status
 
             if status == TASK_RUNNING:


### PR DESCRIPTION
Discovered whilst testing that process.py or cuckoo.py crash in the event that a client deletes a task via the API whilst that task's results are being processed (perhaps due to a client timeout and subsequent cleanup). The API prevents tasks being deleted whilst in the "running" state but allows deletion in the "completed" state. The subsequent attempt to update the task status to "reported" in the database causes a fatal exception.
