### PR TITLE
Don't always run memory processing module.

### DIFF
--- a/modules/processing/memory.py
+++ b/modules/processing/memory.py
@@ -1051,7 +1051,7 @@ class Memory(Processing):
         self.key = "memory"
 
         results = {}
-        if "machine" not in self.task or not self.task["machine"]:
+        if "machine" not in self.task or not self.task["machine"] or not self.task["memory"]:
             return results
 
         task_machine = self.task["machine"]["name"]


### PR DESCRIPTION
Only run it when we specified to run it via --memory or the tickbox in django.
