### PR TITLE
Deleting tasks with identical tags

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -275,7 +275,7 @@ class Task(Base):
     id = Column(Integer(), primary_key=True)
     target = Column(Text(), nullable=False)
     category = Column(String(255), nullable=False)
-    timeout = Column(Integer(), server_default="0", nullable=False)ge
+    timeout = Column(Integer(), server_default="0", nullable=False)
     priority = Column(Integer(), server_default="1", nullable=False)
     custom = Column(String(255), nullable=True)
     machine = Column(String(255), nullable=True)

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.utils import create_folder, Singleton, classlock, SuperLo
 from lib.cuckoo.common.demux import demux_sample
 
 try:
-    from sqlalchemy import create_engine, Column
+    from sqlalchemy import create_engine, Column, event
     from sqlalchemy import Integer, String, Boolean, DateTime, Enum
     from sqlalchemy import ForeignKey, Text, Index, Table
     from sqlalchemy.ext.declarative import declarative_base
@@ -88,8 +88,7 @@ class Machine(Base):
     label = Column(String(255), nullable=False)
     ip = Column(String(255), nullable=False)
     platform = Column(String(255), nullable=False)
-    tags = relationship("Tag", secondary=machines_tags, cascade="all, delete",
-                        single_parent=True, backref=backref("machine", cascade="all"))
+    tags = relationship("Tag", secondary=machines_tags, backref="machines")
     interface = Column(String(255), nullable=True)
     snapshot = Column(String(255), nullable=True)
     locked = Column(Boolean(), nullable=False, default=False)
@@ -276,14 +275,12 @@ class Task(Base):
     id = Column(Integer(), primary_key=True)
     target = Column(Text(), nullable=False)
     category = Column(String(255), nullable=False)
-    timeout = Column(Integer(), server_default="0", nullable=False)
+    timeout = Column(Integer(), server_default="0", nullable=False)ge
     priority = Column(Integer(), server_default="1", nullable=False)
     custom = Column(String(255), nullable=True)
     machine = Column(String(255), nullable=True)
     package = Column(String(255), nullable=True)
-    tags = relationship("Tag", secondary=tasks_tags, cascade="all, delete",
-                        single_parent=True, backref=backref("task", cascade="all"),
-                        lazy="subquery")
+    tags = relationship("Tag", secondary=tasks_tags, backref="tasks", lazy="subquery")
     options = Column(String(255), nullable=True)
     platform = Column(String(255), nullable=True)
     memory = Column(Boolean, nullable=False, default=False)
@@ -410,6 +407,10 @@ class Database(object):
 
         # Get db session.
         self.Session = sessionmaker(bind=self.engine)
+
+        @event.listens_for(self.Session, 'after_flush')
+        def delete_tag_orphans(session, ctx):
+            session.query(Tag).filter(~Tag.tasks.any()).filter(~Tag.machines.any()).delete(synchronize_session=False)
 
         # Deal with schema versioning.
         # TODO: it's a little bit dirty, needs refactoring.


### PR DESCRIPTION
If several tasks are submitted with the same tag, deleting a single task via the API deletes ALL of those tasks.

There is an issue with the bi-directional relationships between the tasks, tasks_tags and tags tables and the unique constraint on the tags table as defined in database.py - causing the delete from the tags table to cascade back and delete all dependent tasks.

Easily reproduced by adding two samples with tag 'a':

curl -F file=@/tmp/sample.exe --form_string "tags=a" http://server/tasks/create/file
curl -F file=@/tmp/sample2.exe --form_string "tags=a" http://server/tasks/create/file

sees the following in the DB tables:

tasks
id=1, target=sample.exe
id=2, target=sample2.exe

tasks_tags
task_id=1, tag_id=1
task_id=2, tag_id=1

tags
id=1, name=a

Then issuing 'curl http://server/tasks/delete/1', both tasks 1 and 2 are deleted and I am left with:

tasks

tasks_tags

tags

Both tasks have been deleted despite only requesting task 1 to be deleted.

This example uses the deprecated API but the same issue exists using the django based API.

This change addresses the issue.  It has been tested quite extensively in an operational system.
