### PR TITLE
fix screenshot result dict in html reporting so we don't use 'shots' …

### DIFF
--- a/data/html/sections/screenshots.html
+++ b/data/html/sections/screenshots.html
@@ -2,8 +2,8 @@
     <div class="section-title">
         <h4>Screenshots</h4>
     </div>
-    {% if results.screenshots %}
-        {% for shot in results.screenshots %}
+    {% if results.shots %}
+        {% for shot in results.shots %}
             <a href="data:image/jpeg;base64,{{shot.data}}"><img class="fade" src="data:image/jpeg;base64,{{shot.data}}" height="100px" width="150px" /></a>
         {% endfor %}
     {% else %}

--- a/modules/reporting/reporthtml.py
+++ b/modules/reporting/reporthtml.py
@@ -51,9 +51,9 @@ class ReportHTML(Report):
                 counter += 1
 
             shots.sort(key=lambda shot: shot["id"])
-            results["screenshots"] = shots
+            results["shots"] = shots
         else:
-            results["screenshots"] = []
+            results["shots"] = []
 
         env = Environment(autoescape=True)
         env.loader = FileSystemLoader(os.path.join(CUCKOO_ROOT,

--- a/modules/reporting/reporthtmlsummary.py
+++ b/modules/reporting/reporthtmlsummary.py
@@ -62,9 +62,9 @@ class ReportHTMLSummary(Report):
                 counter += 1
 
             shots.sort(key=lambda shot: shot["id"])
-            results["screenshots"] = shots
+            results["shots"] = shots
         else:
-            results["screenshots"] = []
+            results["shots"] = []
 
         env = Environment(autoescape=True)
         env.loader = FileSystemLoader(os.path.join(CUCKOO_ROOT,


### PR DESCRIPTION
…in one place and 'screenshots' in the other which will result in them being saved twice in the result database
