### PR TITLE
Fix the Moloch reporting module to work with Suricata eve log tagging

### DIFF
--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -157,6 +157,7 @@ class Suricata(Processing):
                 if parsed["event_type"] == "alert":
                     if parsed["alert"]["signature_id"] not in sid_blacklist:
                         alog = dict()
+                        alog["sid"] = parsed["alert"]["signature_id"]
                         alog["srcport"] = parsed["src_port"]
                         alog["srcip"] = parsed["src_ip"]
                         alog["dstport"] = parsed["dest_port"]


### PR DESCRIPTION
Fixed the Moloch Suricata tagging to work with the parsed dictionary instead of parsing the fast log with regex. Looks like this got changed at some point in the Suricata processing module but the Moloch tagging never got updated to reflect that, which resulted in the module erroring out when both were enabled.
