### PR TITLE
Show the SID of the rule that generated the alert in the Suricata Alerts view

### DIFF
--- a/web/templates/analysis/network/_suricata_alerts.html
+++ b/web/templates/analysis/network/_suricata_alerts.html
@@ -9,6 +9,7 @@
                 <th>Destination IP</th>
                 <th>Destination Port</th>
                 <th>Protocol</th>
+                <th>SID</th>
                 <th>Signature</th>
                 <th>Category</th>
             </tr>
@@ -20,6 +21,7 @@
                 <td>{{alert.dstip}}</td>
                 <td>{{alert.dstport}}</td>
                 <td>{{alert.protocol}}</td>
+                <td>{{alert.sid}}</td>
                 <td>{{alert.signature}}</td>
                 <td>{{alert.category}}</td>
             </tr>


### PR DESCRIPTION
Would be useful to know the SID of the rule that generated the alert when looking at the Suricata Alerts view.
