### PR TITLE
More ES support.

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -925,6 +925,16 @@ def tasks_iocs(request, task_id, detail=None):
     buf = {}
     if repconf.mongodb.get("enabled") and not buf:
         buf = results_db.analysis.find_one({"info.id": int(task_id)})
+    if repconf.elasticsearchdb.get("enabled") and not buf:
+        tmp = es.search(
+                  index="cuckoo-*",
+                  doc_type="analysis",
+                  q="info.id: \"%s\"" % task_id
+               )["hits"]["hits"]
+        if tmp:
+            buf = tmp[-1]["_source"]
+        else:
+            buf = None
     if repconf.jsondump.get("enabled") and not buf:
         jfile = os.path.join(CUCKOO_ROOT, "storage", "analyses",
                              "%s" % task_id, "reports", "report.json")

--- a/web/compare/views.py
+++ b/web/compare/views.py
@@ -3,7 +3,6 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import sys
-import pymongo
 
 from django.conf import settings
 from django.template import RequestContext
@@ -13,27 +12,70 @@ from django.views.decorators.http import require_safe
 sys.path.append(settings.CUCKOO_PATH)
 
 import lib.cuckoo.common.compare as compare
+from lib.cuckoo.common.config import Config
 
-results_db = pymongo.MongoClient(settings.MONGO_HOST, settings.MONGO_PORT)[settings.MONGO_DB]
+enabledconf = dict()
+confdata = Config("reporting").get_config()
+for item in confdata:
+    if confdata[item]["enabled"] == "yes":
+        enabledconf[item] = True
+    else:
+        enabledconf[item] = False
+
+if enabledconf["mongodb"]:
+    import pymongo
+    results_db = pymongo.MongoClient(settings.MONGO_HOST, settings.MONGO_PORT)[settings.MONGO_DB]
+
+if enabledconf["elasticsearchdb"]:
+    from elasticsearch import Elasticsearch
+    es = Elasticsearch(
+             hosts = [{
+                 "host": settings.ELASTIC_HOST,
+                 "port": settings.ELASTIC_PORT,
+             }],
+             timeout = 60
+         )
 
 @require_safe
 def left(request, left_id):
-    left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
+    if enabledconf["mongodb"]:
+        left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
+    if enabledconf["elasticsearchdb"]:
+        hits = es.search(
+                   index="cuckoo-*",
+                   doc_type="analysis",
+                   q="info.id: \"%s\"" % left_id
+                )["hits"]["hits"]
+        if hits:
+            left = hits[-1]["_source"]
+        else:
+            left = None
     if not left:
         return render_to_response("error.html",
                                   {"error": "No analysis found with specified ID"},
                                   context_instance=RequestContext(request))
 
     # Select all analyses with same file hash.
-    records = results_db.analysis.find(
-        {
-            "$and": [
-                {"target.file.md5": left["target"]["file"]["md5"]},
-                {"info.id": {"$ne": int(left_id)}}
-            ]
-        },
-        {"target": 1, "info": 1}
-    )
+    if enabledconf["mongodb"]:
+        records = results_db.analysis.find(
+            {
+                "$and": [
+                    {"target.file.md5": left["target"]["file"]["md5"]},
+                    {"info.id": {"$ne": int(left_id)}}
+                ]
+            },
+            {"target": 1, "info": 1}
+        )
+    if enabledconf["elasticsearchdb"]:
+        records = list()
+        results = es.search(
+                      index="cuckoo-*",
+                      doc_type="analysis",
+                      q="target.file.md5: \"%s\" NOT info.id: \"%s\"" % (
+                            left["target"]["file"]["md5"], left_id)
+                  )["hits"]["hits"]
+        for item in results:
+            records.append(item["_source"])
 
     return render_to_response("compare/left.html",
                               {"left": left, "records": records},
@@ -41,22 +83,44 @@ def left(request, left_id):
 
 @require_safe
 def hash(request, left_id, right_hash):
-    left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
+    if enabledconf["mongodb"]:
+        left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
+    if enabledconf["elasticsearchdb"]:
+        hits = es.search(
+                   index="cuckoo-*",
+                   doc_type="analysis",
+                   q="info.id: \"%s\"" % left_id
+               )["hits"]["hits"]
+        if hits:
+            left = hits[-1]["_source"]
+        else:
+            left = None
     if not left:
         return render_to_response("error.html",
                                   {"error": "No analysis found with specified ID"},
                                   context_instance=RequestContext(request))
 
     # Select all analyses with same file hash.
-    records = results_db.analysis.find(
-        {
-            "$and": [
-                {"target.file.md5": right_hash},
-                {"info.id": {"$ne": int(left_id)}}
-            ]
-        },
-        {"target": 1, "info": 1}
-    )
+    if enabledconf["mongodb"]:
+        records = results_db.analysis.find(
+            {
+                "$and": [
+                    {"target.file.md5": left["target"]["file"]["md5"]},
+                    {"info.id": {"$ne": int(left_id)}}
+                ]
+            },
+            {"target": 1, "info": 1}
+        )
+    if enabledconf["elasticsearchdb"]:
+        records = list()
+        results = es.search(
+                      index="cuckoo-*",
+                      doc_type="analysis",
+                      q="target.file.md5: \"%s\" NOT info.id: \"%s\"" % (
+                            right_hash, left_id)
+                  )["hits"]["hits"]
+        for item in results:
+            records.append(item["_source"])
 
     # Select all analyses with specified file hash.
     return render_to_response("compare/hash.html",
@@ -65,11 +129,23 @@ def hash(request, left_id, right_hash):
 
 @require_safe
 def both(request, left_id, right_id):
-    left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
-    right = results_db.analysis.find_one({"info.id": int(right_id)}, {"target": 1, "info": 1})
-
-    # Execute comparison.
-    counts = compare.helper_percentages_mongo(results_db, left_id, right_id)
+    if enabledconf["mongodb"]:
+        left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
+        right = results_db.analysis.find_one({"info.id": int(right_id)}, {"target": 1, "info": 1})
+        # Execute comparison.
+        counts = compare.helper_percentages_mongo(results_db, left_id, right_id)
+    if enabledconf["elasticsearchdb"]:
+        left = es.search(
+                   index="cuckoo-*",
+                   doc_type="analysis",
+                   q="info.id: \"%s\"" % left_id
+               )["hits"]["hits"][-1]["_source"]
+        right = es.search(
+                    index="cuckoo-*",
+                    doc_type="analysis",
+                    q="info.id: \"%s\"" % right_id
+                )["hits"]["hits"][-1]["_source"]
+        counts = compare.helper_percentages_elastic(es, left_id, right_id)
 
     return render_to_response("compare/both.html",
                               {"left": left, "right": right, "left_counts": counts[left_id],

--- a/web/templates/analysis/report.html
+++ b/web/templates/analysis/report.html
@@ -19,7 +19,9 @@ $(function() {
 </script>
 <div class="row">
     <div class="col-md-6"><p style="margin-bottom: 10px;"><img src="{{ STATIC_URL }}graphic/cuckoo.png" /></p></div>
+    {% if analysis.info.category == "file" and analysis.target %}
     <div class="col-md-6" style="text-align: right;"><a class="btn btn-primary" href="{% url "compare.views.left" analysis.info.id %}">Compare this analysis to...</a></div>
+    {% endif %}
 </div>
 <ul class="nav nav-tabs">
     <li class="active"><a href="#overview" data-toggle="tab">Quick Overview</a></li>

--- a/web/templates/compare/_info.html
+++ b/web/templates/compare/_info.html
@@ -2,7 +2,6 @@
     <thead>
         <tr>
             <th>ID</th>
-            <th>Category</th>
             <th>Name</th>
             <th>MD5</th>
             <th>Machine</th>
@@ -13,7 +12,6 @@
     <tbody>
         <tr>
             <td>{{record.info.id}}</td>
-            <td>{{record.info.category|upper}}</td>
             <td>{{record.target.file.name}}</td>
             <td><a href="{% url "analysis.views.report" record.info.id %}">{{record.target.file.md5}}</a></td>
             <td>{{record.info.machine.name}}</td>


### PR DESCRIPTION
Support ES for the compare view in Django. Also add it to the taskiocs
API node. This should finish up the overall ElasticSearch functionality.
Now we can focus on tuning, as it's still a bit sluggish. Also changed
the analysis report template to only display the compare button for file
analysis tasks.
