### PR TITLE
dns--

### DIFF
--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -370,8 +370,10 @@ class Pcap:
             reqtuple = query["type"], query["request"]
             if reqtuple not in self.dns_requests:
                 self.dns_requests[reqtuple] = query
+                self.dns_answers.add(tuple(query["answers"]))
             else:
                 new_answers = set((i["type"], i["data"]) for i in query["answers"]) - self.dns_answers
+                self.dns_answers |= new_answers
                 self.dns_requests[reqtuple]["answers"] += [dict(type=i[0], data=i[1]) for i in new_answers]
 
         return True


### PR DESCRIPTION
Actually use self.dns_answers and properly deduplicate our dns_requests, for cases where the PCAP has duplicate DNS requests.
