### PR TITLE
Fix up regex, widening character range

### DIFF
--- a/data/yara/memory/darkcomet.yar
+++ b/data/yara/memory/darkcomet.yar
@@ -8,7 +8,7 @@ rule DarkCometConfig
         description = "Configuration for DarkComet"
 
     strings:
-        $buf = /#BEGIN\sDARKCOMET[A-Za-z0-9\r\n\s\-\=\_\{\}\.:]*\#EOF\sDARKCOMET\sDATA\s--/s
+        $buf = /#BEGIN\sDARKCOMET[A-Za-z0-9\r\n\s\-\=\_\{\}\.:\\\/]*\#EOF\sDARKCOMET\sDATA\s--/s
 
     condition:
         $buf


### PR DESCRIPTION
Backslashes can be present in the EDTPATH variable and forward slashes can be present in the EDTDATE variable.
