### PR TITLE
explicitly state that the http.status is a string

### DIFF
--- a/modules/processing/suricata.py
+++ b/modules/processing/suricata.py
@@ -186,7 +186,7 @@ class Suricata(Processing):
                     except:
                         hlog["hostname"] = "None"
                     try:
-                        hlog["status"] = parsed["http"]["status"]
+                        hlog["status"] = str(parsed["http"]["status"])
                     except:
                         hlog["status"] = "None"
                     hlog["method"] = parsed["http"]["http_method"]


### PR DESCRIPTION
this is to avoid error in elasticsearch mapping.
http.status is declared as long type in the elasticsearch index template since it's originally an int.
however, if you encounter a http.status that is "None" later on, this would cause a mapping error since "None" is a string .
so just declare them both as string to avoid the error
