### PR TITLE
Add basic support for authenticode validation

### DIFF
--- a/analyzer/windows/modules/auxiliary/digisig.py
+++ b/analyzer/windows/modules/auxiliary/digisig.py
@@ -1,0 +1,163 @@
+# Copyright (C) 2010-2015 KillerInstinct
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+import json
+import logging
+import os
+from cStringIO import StringIO
+
+from lib.api.utils import Utils
+from lib.common.abstracts import Auxiliary
+from lib.common.constants import ROOT
+from lib.common.results import NetlogFile
+
+log = logging.getLogger(__name__)
+util = Utils()
+
+class DigiSig(Auxiliary):
+    """Runs signtool.exe and parses the output.
+
+    For this to work, the Microsoft tool signtool.exe will need to be placed
+    into the windows/analyzer/bin/ directory. signtool.exe can be downloaded
+    from Microsoft as part of the SDK. (which is also usually packaged with
+    Visual Studio) Once you have a local copy of signtool.exe, enable the
+    module by turning self.enabled to True.
+
+    TODO:
+    Currently the only way to properly update root certificate cab files is
+    via Windows Update which is disabled in many Cuckoo rigs. This means that
+    we will not be able to error out on revoked certificates. Need to find a
+    good work around for this. Ideally make it an option so we don't force
+    log unnecessary update network traffic.
+    """
+    def __init__(self, options, config):
+        Auxiliary.__init__(self, options, config)
+        self.cert_build = list()
+        self.time_build = list()
+        self.json_data = {
+            "sha1": None,
+            "signers": list(),
+            "timestamp": None,
+            "valid": False,
+            "error": None,
+            "error_desc": None
+        }
+        self.enabled = False
+
+    def build_output(self, outputType, line):
+        if line and line != "":
+            if outputType == "cert":
+                self.cert_build.append(line.replace("    ", "-"))
+            elif outputType == "time":
+                self.time_build.append(line.replace("    ", "-"))
+
+    def parse_digisig(self, data):
+        parser_switch = None
+        for line in data.splitlines():
+            if line.startswith("Hash of file (sha1)"):
+                if not self.json_data["sha1"]:
+                    self.json_data["sha1"] = line.split(": ")[-1].lower()
+            # Start of certificate chain information
+            if line.startswith("Signing Certificate Chain:"):
+                parser_switch = "cert"
+                continue
+            # End of certificate chain information
+            if line.startswith("The signature is timestamped:"):
+                parser_switch = None
+                if not self.json_data["timestamp"]:
+                    self.json_data["timestamp"] = line.split(": ")[-1]
+            # Start of timestamp verification
+            if line.startswith("Timestamp Verified by:"):
+                parser_switch = "time"
+                continue
+            # Potential end of timestamp verification
+            if line.startswith("Number of files"):
+                parser_switch = None
+            # Potential end of timestamp verification
+            if line.startswith("Successfully verified"):
+                parser_switch = None
+            if parser_switch == "cert":
+                self.build_output("cert", line)
+            if parser_switch == "time":
+                self.build_output("time", line)
+
+    def jsonify(self, signType, signers):
+        buf = dict()
+        lastnum = "0"
+        for item in signers:
+            num = str(item.split(":")[0].count("-"))
+            signed = signType + " " + num
+            if lastnum != num and buf:
+                self.json_data["signers"].append(buf)
+                buf = dict()
+            key = item.split(":")[0].replace("-", "")
+            value = "".join(item.split(":")[1:]).strip()
+            buf["name"] = signed
+            # Lower case hashes to match the format of other hashes in Django
+            if key == "SHA1 hash":
+                buf[key] = value.lower()
+            else:
+                buf[key] = value
+            lastnum = num
+
+        if buf:
+            self.json_data["signers"].append(buf)
+
+    def start(self):
+        if not self.enabled:
+            return True
+
+        try:
+            if self.config.category != "file":
+                log.debug("Skipping authenticode validation, analysis is not "
+                          "a file.")
+                return True
+
+            sign_path = os.path.join(os.getcwd(), "bin", "signtool.exe")
+            if not os.path.exists(sign_path):
+                log.info("Skipping authenticode validation, signtool.exe was "
+                         "not found in bin/")
+                return True
+
+            log.debug("Checking for a digitial signature.")
+            file_path = os.path.join(os.environ["TEMP"] + os.sep,
+                                     str(self.config.file_name))
+            cmd = '{0} verify /pa /v "{1}"'.format(sign_path, file_path)
+            ret, out, err = util.cmd_wrapper(cmd)
+            # Return was 0, authenticode certificate validated successfully
+            if not ret:
+                output = self.parse_digisig(out)
+                self.jsonify("Certificate Chain", self.cert_build)
+                self.jsonify("Timestamp Chain", self.time_build)
+                self.json_data["valid"] = True
+                log.debug("File has a valid signature.")
+            # Non-zero return, it didn't validate or exist
+            else:
+                self.json_data["error"] = True
+                errmsg = " ".join("".join(err.split(":")[1:]).split())
+                self.json_data["error_desc"] = errmsg
+                if "No signature found" not in err:
+                    log.debug("File has an invalid signature.")
+                    output = self.parse_digisig(out)
+                    self.jsonify("Certificate Chain", self.cert_build)
+                    self.jsonify("Timestamp Chain", self.time_build)
+                else:
+                    log.debug("File is not signed.")
+
+            if self.json_data:
+                log.info("Uploading signature results to aux/{0}.json".format(
+                             self.__class__.__name__))
+                upload = StringIO()
+                upload.write(json.dumps(self.json_data))
+                upload.seek(0)
+                nf = NetlogFile("aux/{0}.json".format(self.__class__.__name__))
+                for chunk in upload:
+                    nf.sock.sendall(chunk)
+                nf.close()
+
+        except Exception:
+            import traceback
+            log.exception(traceback.format_exc())
+
+        return True

--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -293,7 +293,7 @@ class ResultHandler(SocketServer.BaseRequestHandler):
                     str(self.pid), str(self.procname), emsg)
 
     def create_folders(self):
-        folders = "shots", "files", "logs"
+        folders = "shots", "files", "logs", "aux"
 
         for folder in folders:
             try:

--- a/web/templates/analysis/static/_pe32.html
+++ b/web/templates/analysis/static/_pe32.html
@@ -1,4 +1,5 @@
 <section id="static_analysis">
+    {% load key_tags %}
     {% if analysis.static %}
         {% if analysis.static.pe_imagebase or analysis.static.pe_entrypoint or analysis.static.pe_osversion or analysis.static.pe_pdbpath or analysis.static.pe_timestamp or analysis.static.pe_imphash or analysis.static.pe_icon %}
             <div>
@@ -138,6 +139,60 @@
                         </tr>
                     {% endfor %}
                 </table>
+                {% for signature in analysis.static.digital_signers %}
+                {% if signature.aux_sha1 %}
+                <h4>Microsoft Certificate Validation (Sign Tool)</h4>
+                <table class="table table-striped table-bordered">
+                    <tr>
+                        <th width="20%">SHA1</th>
+                        <th width="20%">Timestamp</th>
+                        <th width="5%">Valid</th>
+                        <th width="55%">Error</th>
+                    </tr>
+                    <tr>
+                        <td>{{signature.aux_sha1}}</td>
+                        <td>{{signature.aux_timestamp}}</td>
+                        {% if signature.aux_valid %}
+                        <td><center><span class="label label-success">Yes</span></center></td>
+                        <td>None</td>
+                        {% else %}
+                        <td><center><span class="label label-danger">No</span></center></td>
+                        <td>{{signature.aux_error_desc}}</td>
+                        {% endif %}
+                    </tr>
+                </table>
+                {% for signer in signature.aux_signers %}
+                <table class="table table-striped table-bordered">
+                    <colgroup>
+                        <col style="width:15%">
+                        <col style="width:85%">
+                    </colgroup>
+                    <tbody>
+                        <tr>
+                            <td><b>Chain</b></td>
+                            <td>{{signer.name}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>Issued to</b></td>
+                            <td>{{signer|getkey:"Issued to"}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>Issued by</b></td>
+                            <td>{{signer|getkey:"Issued by"}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>Expires</b></td>
+                            <td>{{signer.Expires}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>SHA1 Hash</b></td>
+                            <td>{{signer|getkey:"SHA1 hash"}}</td>
+                        </tr>
+                    </tbody>
+                 </table>
+                 {% endfor %}
+                 {% endif %}
+                 {% endfor %}
             </div>
         </div>
         <hr />


### PR DESCRIPTION
Accomplished via a guest auxiliary module, which requires the signtool.exe (x86) Microsoft binary to be placed into the analyzer/windows/bin directory.
