### PR TITLE
Add a DNS whitelist to the network.py

### DIFF
--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -15,7 +15,7 @@ enabled = yes
 
 [dropped]
 enabled = yes
-# Amout of text to carve from plaintext files (bytes)
+# Amount of text to carve from plaintext files (bytes)
 buffer = 8192
 
 [memory]
@@ -23,6 +23,11 @@ enabled = no
 
 [network]
 enabled = yes
+# DNS whitelisting to ignore domains/IPs configured in network.py
+# This should be disabled when utilizing InetSim/Remnux as we end up resolving
+# the IP from fakedns which would then remove all domains associated with that
+# resolved IP
+dnswhitelist = no
 
 [procmemory]
 enabled = yes

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -94,7 +94,7 @@ class Pcap:
         self.config = Config()
         # DNS Whitelist
         self.domain_whitelist = [
-            # Certificate Trust Update sites
+            # Certificate Trust Update domains
             "^ocsp\.usertrust\.com$",
             "^ocsp\.comodoca\.com$",
             "^ctldl\.windowsupdate\.com$",
@@ -661,7 +661,7 @@ class Pcap:
             for delip in self.ip_whitelist:
                 if delip in self.unique_hosts:
                     self.unique_hosts.remove(delip)
-        print self.unique_hosts
+
         # Build results dict.
         self.results["hosts"] = self._enrich_hosts(self.unique_hosts)
         self.results["domains"] = self.unique_domains


### PR DESCRIPTION
This will also remove the returned IP from the hosts section. The data is still viewable when looking at the raw udp data.
